### PR TITLE
'entity_class' Configuration Property

### DIFF
--- a/src/ZF/Apigility/TableGatewayAbstractFactory.php
+++ b/src/ZF/Apigility/TableGatewayAbstractFactory.php
@@ -51,7 +51,7 @@ class TableGatewayAbstractFactory implements AbstractFactoryInterface
         $config            = $services->get('Config');
         $dbConnectedConfig = $config['zf-apigility']['db-connected'][$gatewayName];
 
-        $restConfig = array();
+        $restConfig = $dbConnectedConfig;
         if (isset($config['zf-rest'])
             && isset($dbConnectedConfig['controller_service_name'])
             && isset($config['zf-rest'][$dbConnectedConfig['controller_service_name']])

--- a/test/ZFTest/Apigility/TestAsset/Bar.php
+++ b/test/ZFTest/Apigility/TestAsset/Bar.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility\TestAsset;
+
+class Bar
+{
+}


### PR DESCRIPTION
Currently `zf-apigility`'s `module.config.php` makes mention of an available `entity_class` attribute, but as far as I can tell `zf-rest`'s is the only configuration ever used for the `entity_class` property (across all included packages). This patch updates the configuration retrieval to default the `zf-rest` configuration to it's own (`zf-apigility => db-connected`) rather than an empty array, allowing for expected behavior with either configuration setting.

Also, if the `entity_class` property itself is just an artifact from early development, feel free to ignore!
