### PR TITLE
Fix event priority and with it 'unhide code' an event listener.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -6,6 +6,7 @@
 
 namespace ZF\Apigility;
 
+use Zend\Mvc\MvcEvent;
 use Zend\View\Model\JsonModel;
 use ZF\Hal\View\HalJsonModel;
 use ZF\MvcAuth\MvcAuthEvent;
@@ -36,7 +37,7 @@ class Module
 
         $events->attach(MvcAuthEvent::EVENT_AUTHENTICATION_POST, $services->get('ZF\Apigility\MvcAuth\UnauthenticatedListener'), 100);
         $events->attach(MvcAuthEvent::EVENT_AUTHORIZATION_POST, $services->get('ZF\Apigility\MvcAuth\UnauthorizedListener'), 100);
-        $events->attach($e::EVENT_RENDER, array($this, 'onRender'));
+        $events->attach(MvcEvent::EVENT_RENDER, array($this, 'onRender'), 400);
     }
 
     /**


### PR DESCRIPTION
After take a look at the event net, I realize that `Hal` renderer is attached with priority 100, and as the whole point to attach a listener to the event `MvcEvent::EVENT_RENDER_ERROR` is catch any rendering error, this listener attachment ('ZF\ApiProblem\RenderErrorListener' service) must happen before the `Hal`'s renderer listener get executed. I pick 400 as priority value becuase is important that this listener be executed after the `ApiProblemListener::onRender` listener, and the priority of that listener is 1000.
