### PR TITLE
Changed listeners by extending the defaults

### DIFF
--- a/src/ZF/Apigility/MvcAuth/UnauthenticatedListener.php
+++ b/src/ZF/Apigility/MvcAuth/UnauthenticatedListener.php
@@ -32,6 +32,7 @@ class UnauthenticatedListener
 
         $mvcEvent = $mvcAuthEvent->getMvcEvent();
         $response = new ApiProblemResponse(new ApiProblem(401, 'Unauthorized'));
+        $response->getHeaders()->addHeaders($mvcEvent->getResponse()->getHeaders());
         $mvcEvent->setResponse($response);
         return $response;
     }

--- a/src/ZF/Apigility/MvcAuth/UnauthorizedListener.php
+++ b/src/ZF/Apigility/MvcAuth/UnauthorizedListener.php
@@ -27,6 +27,7 @@ class UnauthorizedListener
 
         $mvcEvent = $mvcAuthEvent->getMvcEvent();
         $response = new ApiProblemResponse(new ApiProblem(403, 'Forbidden'));
+        $response->getHeaders()->addHeaders($mvcEvent->getResponse()->getHeaders());
         $mvcEvent->setResponse($response);
         return $response;
     }


### PR DESCRIPTION
Changed `UnauthenticatedListener` and `UnauthorizedListener` by extending the default classes provided by `zf-mvc-auth`. This modification adds the `WWW-Authenticate` header in the 401 and 403 responses when `digest` authentication is set.
