### PR TITLE
Extend Application to allow catching route exceptions

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -35,8 +35,16 @@ class Module
         $services = $app->getServiceManager();
         $events   = $app->getEventManager();
 
-        $events->attach(MvcAuthEvent::EVENT_AUTHENTICATION_POST, $services->get('ZF\Apigility\MvcAuth\UnauthenticatedListener'), 100);
-        $events->attach(MvcAuthEvent::EVENT_AUTHORIZATION_POST, $services->get('ZF\Apigility\MvcAuth\UnauthorizedListener'), 100);
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHENTICATION_POST,
+            $services->get('ZF\Apigility\MvcAuth\UnauthenticatedListener'),
+            100
+        );
+        $events->attach(
+            MvcAuthEvent::EVENT_AUTHORIZATION_POST,
+            $services->get('ZF\Apigility\MvcAuth\UnauthorizedListener'),
+            100
+        );
         $events->attach(MvcEvent::EVENT_RENDER, array($this, 'onRender'), 400);
     }
 

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "php": ">=5.3.23",
         "rwoverdijk/assetmanager": "~1.3",
         "zendframework/zend-db": ">=2.3,<2.5",
+        "zendframework/zend-mvc": ">=2.3,<2.5",
         "zendframework/zend-paginator": ">=2.3,<2.5",
         "zendframework/zend-servicemanager": ">=2.3,<2.5",
         "zfcampus/zf-api-problem": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -29,9 +29,11 @@
         "php": ">=5.3.23",
         "rwoverdijk/assetmanager": "~1.3",
         "zendframework/zend-db": ">=2.3,<2.5",
+        "zendframework/zend-eventmanager": ">=2.3,<2.5",
         "zendframework/zend-mvc": ">=2.3,<2.5",
         "zendframework/zend-paginator": ">=2.3,<2.5",
         "zendframework/zend-servicemanager": ">=2.3,<2.5",
+        "zendframework/zend-stdlib": ">=2.3,<2.5",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-apigility-provider": "~1.0",
         "zfcampus/zf-content-negotiation": "~1.0",
@@ -47,9 +49,7 @@
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3",
         "zendframework/zend-http": ">=2.3,<2.5",
-        "zendframework/zend-loader": ">=2.3,<2.5",
-        "zendframework/zend-mvc": ">=2.3,<2.5",
-        "zendframework/zend-stdlib": ">=2.3,<2.5"
+        "zendframework/zend-loader": ">=2.3,<2.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,5 +17,6 @@
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+    <file>Module.php</file>
     <exclude-pattern>*/test/TestAsset/*_*</exclude-pattern>
 </ruleset>

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZF\Apigility;
+
+use Exception;
+use Zend\Mvc\Application as MvcApplication;
+use Zend\Mvc\MvcEvent;
+use Zend\Stdlib\ResponseInterface;
+
+class Application extends MvcApplication
+{
+    /**
+     * Run the application.
+     *
+     * {@inheritDoc}
+     *
+     * This method overrides the behavior of Zend\Mvc\Application to wrap the
+     * trigger of the route event in a try/catch block, allowing us to catch
+     * route listener exceptions and trigger the dispatch.error event.
+     *
+     * @triggers route(MvcEvent)
+     *           Routes the request, and sets the RouteMatch object in the event.
+     * @triggers dispatch(MvcEvent)
+     *           Dispatches a request, using the discovered RouteMatch and
+     *           provided request.
+     * @triggers dispatch.error(MvcEvent)
+     *           On errors (controller not found, action not supported, etc.),
+     *           populates the event with information about the error type,
+     *           discovered controller, and controller class (if known).
+     *           Typically, a handler should return a populated Response object
+     *           that can be returned immediately.
+     * @return self
+     */
+    public function run()
+    {
+        $events = $this->events;
+        $event  = $this->event;
+
+        // Define callback used to determine whether or not to short-circuit
+        $shortCircuit = function ($r) use ($event) {
+            if ($r instanceof ResponseInterface) {
+                return true;
+            }
+            if ($event->getError()) {
+                return true;
+            }
+            return false;
+        };
+
+        // Trigger route event
+        try {
+            $result = $events->trigger(MvcEvent::EVENT_ROUTE, $event, $shortCircuit);
+        } catch (Exception $e) {
+            $event->setError(self::ERROR_EXCEPTION)
+                ->setParam('exception', $e);
+            $result = $events->trigger(MvcEvent::EVENT_DISPATCH_ERROR, $event);
+
+            $response = $result->last();
+            if ($response instanceof ResponseInterface) {
+                $event->setTarget($this);
+                $event->setResponse($response);
+                $this->response = $response;
+                $events->trigger(MvcEvent::EVENT_FINISH, $event);
+                return $this;
+            }
+
+            return $this->completeRequest($event);
+        }
+
+        if ($result->stopped()) {
+            $response = $result->last();
+            if ($response instanceof ResponseInterface) {
+                $event->setTarget($this);
+                $event->setResponse($response);
+                $events->trigger(MvcEvent::EVENT_FINISH, $event);
+                $this->response = $response;
+                return $this;
+            }
+        }
+
+        if ($event->getError()) {
+            return $this->completeRequest($event);
+        }
+
+        // Trigger dispatch event
+        $result = $events->trigger(MvcEvent::EVENT_DISPATCH, $event, $shortCircuit);
+
+        // Complete response
+        $response = $result->last();
+        if ($response instanceof ResponseInterface) {
+            $event->setTarget($this);
+            $event->setResponse($response);
+            $events->trigger(MvcEvent::EVENT_FINISH, $event);
+            $this->response = $response;
+            return $this;
+        }
+
+        $response = $this->response;
+        $event->setResponse($response);
+        $this->completeRequest($event);
+
+        return $this;
+    }
+}

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+namespace ZFTest\Apigility;
+
+use Exception;
+use PHPUnit_Framework_TestCase as TestCase;
+use ReflectionProperty;
+use Zend\EventManager\EventManager;
+use Zend\Mvc\MvcEvent;
+use ZF\Apigility\Application;
+
+class ApplicationTest extends TestCase
+{
+    public function setUp()
+    {
+        $events = new EventManager();
+
+        $request = $this->getMockBuilder('Zend\Http\PhpEnvironment\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $response = $this->getMockBuilder('Zend\Http\PhpEnvironment\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $services = $this->getMockBuilder('Zend\ServiceManager\ServiceManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->services = $services = $this->setUpServices($services, $events, $request, $response);
+
+        $app = new Application(array(), $services);
+        $this->app = $app = $this->setUpMvcEvent($app, $request, $response);
+    }
+
+    public function setUpServices($services, $events, $request, $response)
+    {
+        $services->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo('EventManager'))
+            ->willReturn($events);
+        $services->expects($this->at(1))
+            ->method('get')
+            ->with($this->equalTo('Request'))
+            ->willReturn($request);
+        $services->expects($this->at(2))
+            ->method('get')
+            ->with($this->equalTo('Response'))
+            ->willReturn($response);
+
+        return $services;
+    }
+
+    public function setUpMvcEvent($app, $request, $response)
+    {
+        $event = new MvcEvent();
+        $event->setTarget($app);
+        $event->setApplication($app)
+            ->setRequest($request)
+            ->setResponse($response);
+        $r = new ReflectionProperty($app, 'event');
+        $r->setAccessible(true);
+        $r->setValue($app, $event);
+        return $app;
+    }
+
+    public function testRouteListenerRaisingExceptionTriggersDispatchErrorAndSkipsDispatch()
+    {
+        $phpunit  = $this;
+        $events   = $this->app->getEventManager();
+        $response = $this->getMockBuilder('Zend\Http\PhpEnvironment\Response')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $events->attach('route', function ($e) {
+            throw new Exception();
+        });
+
+        $events->attach('dispatch.error', function ($e) use ($phpunit, $response) {
+            $phpunit->assertNotEmpty($e->getError());
+            return $response;
+        });
+
+        $events->attach('dispatch', function ($e) use ($phpunit) {
+            $phpunit->fail('dispatch event triggered when it should not be');
+        });
+
+        $events->attach('render', function ($e) use ($phpunit) {
+            $phpunit->fail('render event triggered when it should not be');
+        });
+
+        $finishTriggered = false;
+        $events->attach('finish', function ($e) use (&$finishTriggered) {
+            $finishTriggered = true;
+        });
+
+        $this->app->run();
+        $this->assertTrue($finishTriggered);
+        $this->assertSame($response, $this->app->getResponse());
+    }
+}

--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -64,7 +64,9 @@ class TableGatewayAbstractFactoryTest extends TestCase
         $this->services->set('Config', array(
             'zf-apigility' => array(
                 'db-connected' => array(
-                    'Foo' => array('table_name' => 'test'),
+                    'Foo' => array(
+                        'table_name' => 'test',
+                    ),
                 ),
             ),
         ));


### PR DESCRIPTION
This patch provides a new class, `ZF\Apigility\Application`, which extends `Zend\Mvc\Application` to provide a try/catch block around the route event.  This addresses the concerns raised in zfcampus/zf-apigility-skeleton#83, as it means any exception raised by a route listener will be caught and lead to triggering the `dispatch.error` event. In the case of Apigility applications, this will allow us to return problem details.

This will require updating zfcampus/zf-apigility-skeleton to use the new class instead of `Zend\Mvc\Application` in its `public/index.php`.