### PR TITLE
Updated minimum versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
         }
     },
     "require": {
-        "php": ">=5.3.23",
+        "php": ">=5.5",
         "rwoverdijk/assetmanager": "~1.3",
-        "zendframework/zend-db": ">=2.3,<2.5",
-        "zendframework/zend-eventmanager": ">=2.3,<2.5",
-        "zendframework/zend-mvc": ">=2.3,<2.5",
-        "zendframework/zend-paginator": ">=2.3,<2.5",
-        "zendframework/zend-servicemanager": ">=2.3,<2.5",
-        "zendframework/zend-stdlib": ">=2.3,<2.5",
+        "zendframework/zend-db": "~2.3",
+        "zendframework/zend-eventmanager": "~2.3",
+        "zendframework/zend-mvc": "~2.3",
+        "zendframework/zend-paginator": "~2.3",
+        "zendframework/zend-servicemanager": "~2.3",
+        "zendframework/zend-stdlib": "~2.3",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-apigility-provider": "~1.0",
         "zfcampus/zf-content-negotiation": "~1.0",
@@ -48,8 +48,8 @@
     "require-dev": {
         "phpunit/phpunit": "~4.7",
         "squizlabs/php_codesniffer": "^2.3",
-        "zendframework/zend-http": ">=2.3,<2.5",
-        "zendframework/zend-loader": ">=2.3,<2.5"
+        "zendframework/zend-http": "~2.3",
+        "zendframework/zend-loader": "~2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- PHP 5.5
- which allows us to use `~2.3` for zf deps again, which will bring in 2.5! \o/

This will be for the next minor version.