### PR TITLE
Update Travis-CI and phpcs to reflect PHP 5.5 change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-    - php: 5.4
     - php: 5.5
       env:
         - EXECUTE_CS_CHECK=true

--- a/Module.php
+++ b/Module.php
@@ -15,13 +15,13 @@ class Module
 {
     public function getAutoloaderConfig()
     {
-        return array(
-            'Zend\Loader\StandardAutoloader' => array(
-                'namespaces' => array(
+        return [
+            'Zend\Loader\StandardAutoloader' => [
+                'namespaces' => [
                     __NAMESPACE__ => __DIR__ . '/src/',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 
     public function getConfig()
@@ -45,7 +45,7 @@ class Module
             $services->get('ZF\Apigility\MvcAuth\UnauthorizedListener'),
             100
         );
-        $events->attach(MvcEvent::EVENT_RENDER, array($this, 'onRender'), 400);
+        $events->attach(MvcEvent::EVENT_RENDER, [$this, 'onRender'], 400);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",
-        "squizlabs/php_codesniffer": "^2.3",
+        "squizlabs/php_codesniffer": "^2.3.1",
         "zendframework/zend-http": "~2.3",
         "zendframework/zend-loader": "~2.3"
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
 
     <!-- inherit rules from: -->
     <rule ref="PSR2"/>
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/> 
     <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
         <properties>
             <property name="ignoreBlankLines" value="false"/>

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -28,7 +28,7 @@ class Autoloader extends StandardAutoloader
     {
         // $class may contain a namespace portion, in  which case we need
         // to preserve any underscores in that portion.
-        $matches = array();
+        $matches = [];
         preg_match('/(?P<namespace>.+\\\)?(?P<class>[^\\\]+$)/', $class, $matches);
 
         $class     = (isset($matches['class'])) ? $matches['class'] : '';

--- a/src/DbConnectedResource.php
+++ b/src/DbConnectedResource.php
@@ -36,7 +36,7 @@ class DbConnectedResource extends AbstractResourceListener
     public function update($id, $data)
     {
         $data = $this->retrieveData($data);
-        $this->table->update($data, array($this->identifierName => $id));
+        $this->table->update($data, [$this->identifierName => $id]);
         return $this->fetch($id);
     }
 
@@ -47,20 +47,20 @@ class DbConnectedResource extends AbstractResourceListener
 
     public function delete($id)
     {
-        $item = $this->table->delete(array($this->identifierName => $id));
+        $item = $this->table->delete([$this->identifierName => $id]);
         return ($item > 0);
     }
 
     public function fetch($id)
     {
-        $resultSet = $this->table->select(array($this->identifierName => $id));
+        $resultSet = $this->table->select([$this->identifierName => $id]);
         if (0 === $resultSet->count()) {
             throw new \Exception('Item not found', 404);
         }
         return $resultSet->current();
     }
 
-    public function fetchAll($data = array())
+    public function fetchAll($data = [])
     {
         $adapter = new TableGatewayPaginator($this->table);
         return new $this->collectionClass($adapter);

--- a/src/Model/MongoConnectedListener.php
+++ b/src/Model/MongoConnectedListener.php
@@ -61,8 +61,8 @@ class MongoConnectedListener extends AbstractResourceListener
     public function patch($id, $data)
     {
         $result = $this->collection->update(
-            array( '_id' => new MongoId($id) ),
-            array( '$set' => $data )
+            [ '_id' => new MongoId($id) ],
+            [ '$set' => $data ]
         );
 
         if (isset($result['ok']) && $result['ok']) {
@@ -79,9 +79,9 @@ class MongoConnectedListener extends AbstractResourceListener
      */
     public function fetch($id)
     {
-        $result = $this->collection->findOne(array(
+        $result = $this->collection->findOne([
             '_id' => new MongoId($id)
-        ));
+        ]);
 
         if (null === $result) {
             return new ApiProblem(404, 'Document not found in the collection');
@@ -96,11 +96,11 @@ class MongoConnectedListener extends AbstractResourceListener
      * @param  array $params
      * @return MongoCursor
      */
-    public function fetchAll($params = array())
+    public function fetchAll($params = [])
     {
         // @todo How to handle the pagination?
         $rows = $this->collection->find($params);
-        $result = array();
+        $result = [];
         foreach ($rows as $id => $collection) {
             unset($collection['_id']);
             $result[$id] = $collection;
@@ -116,9 +116,9 @@ class MongoConnectedListener extends AbstractResourceListener
      */
     public function delete($id)
     {
-        $result = $this->collection->remove(array(
+        $result = $this->collection->remove([
             '_id' => new MongoId($id)
-        ));
+        ]);
         if (isset($result['ok']) && $result['ok']) {
             return true;
         }

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -31,7 +31,7 @@ class ApplicationTest extends TestCase
             ->getMock();
         $this->services = $services = $this->setUpServices($services, $events, $request, $response);
 
-        $app = new Application(array(), $services);
+        $app = new Application([], $services);
         $this->app = $app = $this->setUpMvcEvent($app, $request, $response);
     }
 

--- a/test/AutoloaderTest.php
+++ b/test/AutoloaderTest.php
@@ -13,10 +13,10 @@ class AutoloaderTest extends TestCase
 {
     public function classesToAutoload()
     {
-        return array(
-            'Foo_Bar'         => array('ZFTest\Apigility\TestAsset\Foo_Bar'),
-            'Foo_Bar\Baz_Bat' => array('ZFTest\Apigility\TestAsset\Foo_Bar\Baz_Bat'),
-        );
+        return [
+            'Foo_Bar'         => ['ZFTest\Apigility\TestAsset\Foo_Bar'],
+            'Foo_Bar\Baz_Bat' => ['ZFTest\Apigility\TestAsset\Foo_Bar\Baz_Bat'],
+        ];
     }
 
     /**
@@ -24,11 +24,11 @@ class AutoloaderTest extends TestCase
      */
     public function testAutoloaderDoesNotTransformUnderscoresToDirectorySeparators($className)
     {
-        $autoloader = new Autoloader(array(
-            'namespaces' => array(
+        $autoloader = new Autoloader([
+            'namespaces' => [
                 'ZFTest\Apigility\TestAsset' => __DIR__ . '/TestAsset',
-            ),
-        ));
+            ],
+        ]);
         $result = $autoloader->autoload($className);
         $this->assertFalse(false === $result);
         $this->assertTrue(class_exists($className, false));

--- a/test/DbConnectedResourceAbstractFactoryTest.php
+++ b/test/DbConnectedResourceAbstractFactoryTest.php
@@ -25,38 +25,38 @@ class DbConnectedResourceAbstractFactoryTest extends TestCase
 
     public function testWillNotCreateServiceIfApigilityConfigMissing()
     {
-        $this->services->set('Config', array());
+        $this->services->set('Config', []);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
     }
 
     public function testWillNotCreateServiceIfApigilityConfigIsNotAnArray()
     {
-        $this->services->set('Config', array('zf-apigility' => 'invalid'));
+        $this->services->set('Config', ['zf-apigility' => 'invalid']);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
     }
 
     public function testWillNotCreateServiceIfApigilityConfigDoesNotHaveDbConnectedSegment()
     {
-        $this->services->set('Config', array('zf-apigility' => array('foo' => 'bar')));
+        $this->services->set('Config', ['zf-apigility' => ['foo' => 'bar']]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
     }
 
     public function testWillNotCreateServiceIfDbConnectedSegmentDoesNotHaveRequestedName()
     {
-        $this->services->set('Config', array('zf-apigility' => array(
-            'db-connected' => array(
+        $this->services->set('Config', ['zf-apigility' => [
+            'db-connected' => [
                 'bar' => 'baz',
-            ),
-        )));
+            ],
+        ]]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
     }
 
     public function invalidConfig()
     {
-        return array(
-            'invalid_table_service' => array(array('table_service' => 'non_existent')),
-            'invalid_virtual_table' => array(array()),
-        );
+        return [
+            'invalid_table_service' => [['table_service' => 'non_existent']],
+            'invalid_virtual_table' => [[]],
+        ];
     }
 
     /**
@@ -64,21 +64,21 @@ class DbConnectedResourceAbstractFactoryTest extends TestCase
      */
     public function testWillNotCreateServiceIfDbConnectedSegmentIsInvalidConfiguration($configForDbConnected)
     {
-        $config = array('zf-apigility' => array(
-            'db-connected' => array(
+        $config = ['zf-apigility' => [
+            'db-connected' => [
                 'Foo' => $configForDbConnected,
-            ),
-        ));
+            ],
+        ]];
         $this->services->set('Config', $config);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
     }
 
     public function validConfig()
     {
-        return array(
-            'table_service' => array(array('table_service' => 'foobartable'), 'foobartable'),
-            'virtual_table' => array(array(), 'Foo\Table'),
-        );
+        return [
+            'table_service' => [['table_service' => 'foobartable'], 'foobartable'],
+            'virtual_table' => [[], 'Foo\Table'],
+        ];
     }
 
     /**
@@ -86,11 +86,11 @@ class DbConnectedResourceAbstractFactoryTest extends TestCase
      */
     public function testWillCreateServiceIfDbConnectedSegmentIsValid($configForDbConnected, $tableServiceName)
     {
-        $config = array('zf-apigility' => array(
-            'db-connected' => array(
+        $config = ['zf-apigility' => [
+            'db-connected' => [
                 'Foo' => $configForDbConnected,
-            ),
-        ));
+            ],
+        ]];
         $this->services->set('Config', $config);
         $this->services->set($tableServiceName, new stdClass());
         $this->assertTrue($this->factory->canCreateServiceWithName($this->services, 'foo', 'Foo'));
@@ -106,11 +106,11 @@ class DbConnectedResourceAbstractFactoryTest extends TestCase
             ->getMock();
         $this->services->set($tableServiceName, $tableGateway);
 
-        $config = array('zf-apigility' => array(
-            'db-connected' => array(
+        $config = ['zf-apigility' => [
+            'db-connected' => [
                 'Foo' => $configForDbConnected,
-            ),
-        ));
+            ],
+        ]];
         $this->services->set('Config', $config);
 
         $resource = $this->factory->createServiceWithName($this->services, 'foo', 'Foo');

--- a/test/DbConnectedResourceTest.php
+++ b/test/DbConnectedResourceTest.php
@@ -31,10 +31,10 @@ class DbConnectedResourceTest extends TestCase
 
     public function testCreatePullsDataFromComposedInputFilterWhenPresent()
     {
-        $filtered = array(
+        $filtered = [
             'foo' => 'BAR',
             'baz' => 'QUZ',
-        );
+        ];
 
         $filter = $this->getMock('Zend\InputFilter\InputFilter');
         $filter->expects($this->once())
@@ -55,7 +55,7 @@ class DbConnectedResourceTest extends TestCase
 
         $this->table->expects($this->once())
             ->method('select')
-            ->with($this->equalTo(array('id' => 'foo')))
+            ->with($this->equalTo(['id' => 'foo']))
             ->will($this->returnValue($resultSet));
 
         $resultSet->expects($this->once())
@@ -66,15 +66,15 @@ class DbConnectedResourceTest extends TestCase
             ->method('current')
             ->will($this->returnValue($filtered));
 
-        $this->assertEquals($filtered, $this->resource->create(array('foo' => 'bar')));
+        $this->assertEquals($filtered, $this->resource->create(['foo' => 'bar']));
     }
 
     public function testUpdatePullsDataFromComposedInputFilterWhenPresent()
     {
-        $filtered = array(
+        $filtered = [
             'foo' => 'BAR',
             'baz' => 'QUZ',
-        );
+        ];
 
         $filter = $this->getMock('Zend\InputFilter\InputFilter');
         $filter->expects($this->once())
@@ -87,14 +87,14 @@ class DbConnectedResourceTest extends TestCase
             ->method('update')
             ->with(
                 $this->equalTo($filtered),
-                array('id' => 'foo')
+                ['id' => 'foo']
             );
 
         $resultSet = $this->getMock('Zend\Db\ResultSet\AbstractResultSet');
 
         $this->table->expects($this->once())
             ->method('select')
-            ->with($this->equalTo(array('id' => 'foo')))
+            ->with($this->equalTo(['id' => 'foo']))
             ->will($this->returnValue($resultSet));
 
         $resultSet->expects($this->once())
@@ -105,15 +105,15 @@ class DbConnectedResourceTest extends TestCase
             ->method('current')
             ->will($this->returnValue($filtered));
 
-        $this->assertEquals($filtered, $this->resource->update('foo', array('foo' => 'bar')));
+        $this->assertEquals($filtered, $this->resource->update('foo', ['foo' => 'bar']));
     }
 
     public function testPatchPullsDataFromComposedInputFilterWhenPresent()
     {
-        $filtered = array(
+        $filtered = [
             'foo' => 'BAR',
             'baz' => 'QUZ',
-        );
+        ];
 
         $filter = $this->getMock('Zend\InputFilter\InputFilter');
         $filter->expects($this->once())
@@ -126,14 +126,14 @@ class DbConnectedResourceTest extends TestCase
             ->method('update')
             ->with(
                 $this->equalTo($filtered),
-                array('id' => 'foo')
+                ['id' => 'foo']
             );
 
         $resultSet = $this->getMock('Zend\Db\ResultSet\AbstractResultSet');
 
         $this->table->expects($this->once())
             ->method('select')
-            ->with($this->equalTo(array('id' => 'foo')))
+            ->with($this->equalTo(['id' => 'foo']))
             ->will($this->returnValue($resultSet));
 
         $resultSet->expects($this->once())
@@ -144,6 +144,6 @@ class DbConnectedResourceTest extends TestCase
             ->method('current')
             ->will($this->returnValue($filtered));
 
-        $this->assertEquals($filtered, $this->resource->patch('foo', array('foo' => 'bar')));
+        $this->assertEquals($filtered, $this->resource->patch('foo', ['foo' => 'bar']));
     }
 }

--- a/test/Model/MongoConnectedListenerTest.php
+++ b/test/Model/MongoConnectedListenerTest.php
@@ -42,7 +42,7 @@ class MongoConnectedListenerTest extends TestCase
 
     public function testCreate()
     {
-        $data = array( 'foo' => 'bar' );
+        $data = [ 'foo' => 'bar' ];
         $result = $this->mongoListener->create($data);
         $this->assertTrue(isset($result['_id']));
         static::$lastId = $result['_id'];
@@ -55,7 +55,7 @@ class MongoConnectedListenerTest extends TestCase
                 'This test cannot be executed.'
             );
         }
-        $data = array( 'foo' => 'baz' );
+        $data = [ 'foo' => 'baz' ];
         $this->assertTrue($this->mongoListener->patch(static::$lastId, $data));
     }
 
@@ -75,12 +75,12 @@ class MongoConnectedListenerTest extends TestCase
     {
         $num = 3;
         for ($i=0; $i < $num; $i++) {
-            $this->mongoListener->create(array(
+            $this->mongoListener->create([
                 'foo'   => 'bau',
                 'count' => $i
-            ));
+            ]);
         }
-        $data = array( 'foo' => 'bau' );
+        $data = [ 'foo' => 'bau' ];
         $result = $this->mongoListener->fetchAll($data);
         $this->assertTrue(!empty($result));
         $this->assertTrue(is_array($result));

--- a/test/TableGatewayAbstractFactoryTest.php
+++ b/test/TableGatewayAbstractFactoryTest.php
@@ -31,54 +31,54 @@ class TableGatewayAbstractFactoryTest extends TestCase
 
     public function testWillNotCreateServiceIfMissingApigilityConfig()
     {
-        $this->services->set('Config', array());
+        $this->services->set('Config', []);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillNotCreateServiceIfMissingDbConnectedConfigSegment()
     {
-        $this->services->set('Config', array('zf-apigility' => array()));
+        $this->services->set('Config', ['zf-apigility' => []]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillNotCreateServiceIfMissingServiceSubSegment()
     {
-        $this->services->set('Config', array('zf-apigility' => array('db-connected' => array())));
+        $this->services->set('Config', ['zf-apigility' => ['db-connected' => []]]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillNotCreateServiceIfServiceSubSegmentIsInvalid()
     {
-        $this->services->set('Config', array('zf-apigility' => array('db-connected' => array('Foo' => 'invalid'))));
+        $this->services->set('Config', ['zf-apigility' => ['db-connected' => ['Foo' => 'invalid']]]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillNotCreateServiceIfServiceSubSegmentDoesNotContainTableName()
     {
-        $this->services->set('Config', array('zf-apigility' => array('db-connected' => array('Foo' => array()))));
+        $this->services->set('Config', ['zf-apigility' => ['db-connected' => ['Foo' => []]]]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillNotCreateServiceIfServiceSubSegmentDoesNotContainAdapterInformation()
     {
-        $this->services->set('Config', array(
-            'zf-apigility' => array(
-                'db-connected' => array(
-                    'Foo' => array(
+        $this->services->set('Config', [
+            'zf-apigility' => [
+                'db-connected' => [
+                    'Foo' => [
                         'table_name' => 'test',
-                    ),
-                ),
-            ),
-        ));
+                    ],
+                ],
+            ],
+        ]);
         $this->assertFalse($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
     }
 
     public function testWillCreateServiceIfConfigContainsValidTableNameAndAdapterName()
     {
-        $this->services->set('Config', array('zf-apigility' => array('db-connected' => array('Foo' => array(
+        $this->services->set('Config', ['zf-apigility' => ['db-connected' => ['Foo' => [
             'table_name'   => 'test',
             'adapter_name' => 'FooAdapter',
-        )))));
+        ]]]]);
 
         $this->services->set('FooAdapter', new stdClass());
         $this->assertTrue($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
@@ -86,9 +86,9 @@ class TableGatewayAbstractFactoryTest extends TestCase
 
     public function testWillCreateServiceIfConfigContainsValidTableNameNoAdapterNameAndServicesContainDefaultAdapter()
     {
-        $this->services->set('Config', array('zf-apigility' => array('db-connected' => array('Foo' => array(
+        $this->services->set('Config', ['zf-apigility' => ['db-connected' => ['Foo' => [
             'table_name'   => 'test',
-        )))));
+        ]]]]);
 
         $this->services->set('Zend\Db\Adapter\Adapter', new stdClass());
         $this->assertTrue($this->factory->canCreateServiceWithName($this->services, 'footable', 'Foo\Table'));
@@ -96,10 +96,10 @@ class TableGatewayAbstractFactoryTest extends TestCase
 
     public function validConfig()
     {
-        return array(
-            'named_adapter'   => array('Db\NamedAdapter'),
-            'default_adapter' => array('Zend\Db\Adapter\Adapter'),
-        );
+        return [
+            'named_adapter'   => ['Db\NamedAdapter'],
+            'default_adapter' => ['Zend\Db\Adapter\Adapter'],
+        ];
     }
 
     /**
@@ -125,22 +125,22 @@ class TableGatewayAbstractFactoryTest extends TestCase
 
         $this->services->set($adapterServiceName, $adapter);
 
-        $config = array(
-            'zf-apigility' => array(
-                'db-connected' => array(
-                    'Foo' => array(
+        $config = [
+            'zf-apigility' => [
+                'db-connected' => [
+                    'Foo' => [
                         'controller_service_name' => 'Foo\Controller',
                         'table_name'              => 'foo',
                         'hydrator_name'           => 'ClassMethods',
-                    ),
-                ),
-            ),
-            'zf-rest' => array(
-                'Foo\Controller' => array(
+                    ],
+                ],
+            ],
+            'zf-rest' => [
+                'Foo\Controller' => [
                     'entity_class' => 'ZFTest\Apigility\TestAsset\Foo',
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
         if ($adapterServiceName !== 'Zend\Db\Adapter\Adapter') {
             $config['zf-apigility']['db-connected']['Foo']['adapter_name'] = $adapterServiceName;
         }
@@ -179,18 +179,18 @@ class TableGatewayAbstractFactoryTest extends TestCase
 
         $this->services->set($adapterServiceName, $adapter);
 
-        $config = array(
-            'zf-apigility' => array(
-                'db-connected' => array(
-                    'Foo' => array(
+        $config = [
+            'zf-apigility' => [
+                'db-connected' => [
+                    'Foo' => [
                         'controller_service_name' => 'Foo\Controller',
                         'table_name'              => 'foo',
                         'hydrator_name'           => 'ClassMethods',
                         'entity_class'            => 'ZFTest\Apigility\TestAsset\Bar'
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         if ($adapterServiceName !== 'Zend\Db\Adapter\Adapter') {
             $config['zf-apigility']['db-connected']['Foo']['adapter_name'] = $adapterServiceName;
         }

--- a/test/TestAsset/ServiceManager.php
+++ b/test/TestAsset/ServiceManager.php
@@ -11,7 +11,7 @@ use Zend\ServiceManager\ServiceLocatorInterface;
 
 class ServiceManager implements ServiceLocatorInterface
 {
-    protected $services = array();
+    protected $services = [];
 
     public function get($name)
     {


### PR DESCRIPTION
- Removes 5.3 and 5.4 from test matrix
- Updates phpcs rules to disallow long-form array notation