### PR TITLE
Fixed dep version of zend-stdlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-paginator": "~2.3",
         "zendframework/zend-servicemanager": "~2.3",
-        "zendframework/zend-stdlib": "~2.3",
+        "zendframework/zend-stdlib": ">=2.3 <2.7",
         "zfcampus/zf-api-problem": "~1.0",
         "zfcampus/zf-apigility-provider": "~1.0",
         "zfcampus/zf-content-negotiation": "~1.0",


### PR DESCRIPTION
This fix prevents the update of `zend-stdlib` to version 2.7, which breaks backward compatibility. This should require a new tag and release.